### PR TITLE
Update to Velocity 3.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,11 @@
 **/out/**
 
 **/.gradle/**
+
+**/bin/**
+
+.settings/
+.classpath
+.factorypath
+.project
+.vscode/

--- a/build.gradle
+++ b/build.gradle
@@ -12,11 +12,15 @@ repositories {
     mavenCentral()
     maven {
         name = 'spigot-repo'
-        url = 'https://hub.spigotmc.org/nexus/content/groups/public/'
+        url = 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/'
     }
     maven {
-        name = 'velocity-repo'
-        url = 'https://repo.velocitypowered.com/snapshots/'
+        name = 'bungee-repo'
+        url = 'https://oss.sonatype.org/content/repositories/snapshots'
+    }
+    maven {
+        name 'velocity-repo'
+        url 'https://nexus.velocitypowered.com/repository/maven-public/'
     }
     maven {
         name = 'sponge-repo'
@@ -25,8 +29,9 @@ repositories {
 }
 
 dependencies {
-    compileOnly 'org.bukkit:bukkit:1.13.1-R0.1-SNAPSHOT'
-    compileOnly 'net.md-5:bungeecord-api:1.13-SNAPSHOT'
-    compileOnly 'com.velocitypowered:velocity-api:1.0-SNAPSHOT'
-    compileOnly 'org.spongepowered:spongeapi:7.1.0-SNAPSHOT'
+    implementation 'org.spigotmc:spigot-api:1.17.1-R0.1-SNAPSHOT'
+    implementation 'net.md-5:bungeecord-api:1.17-R0.1-SNAPSHOT'
+    implementation 'com.velocitypowered:velocity-api:3.0.1'
+    annotationProcessor 'com.velocitypowered:velocity-api:3.0.1'
+    implementation 'org.spongepowered:spongeapi:7.1.0-SNAPSHOT'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 group 'me.bhop'
-version '1.0'
+version '1.1'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.8-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip

--- a/src/main/java/me/bhop/lanbroadcaster/sponge/LANBroadcasterSponge.java
+++ b/src/main/java/me/bhop/lanbroadcaster/sponge/LANBroadcasterSponge.java
@@ -8,7 +8,6 @@ import org.spongepowered.api.event.game.state.GameStartedServerEvent;
 import org.spongepowered.api.event.game.state.GameStoppingServerEvent;
 import org.spongepowered.api.plugin.Plugin;
 import org.spongepowered.api.scheduler.Task;
-import org.spongepowered.api.text.serializer.TextSerializers;
 
 import java.util.logging.Logger;
 

--- a/src/main/java/me/bhop/lanbroadcaster/velocity/LANBroadcasterVelocity.java
+++ b/src/main/java/me/bhop/lanbroadcaster/velocity/LANBroadcasterVelocity.java
@@ -8,7 +8,7 @@ import com.velocitypowered.api.plugin.Plugin;
 import com.velocitypowered.api.plugin.annotation.DataDirectory;
 import com.velocitypowered.api.proxy.ProxyServer;
 import me.bhop.lanbroadcaster.LANBroadcaster;
-import net.kyori.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.slf4j.Logger;
 
 import java.nio.file.Path;
@@ -28,7 +28,7 @@ public class LANBroadcasterVelocity {
         this.broadcaster = new LANBroadcaster(
                 LANBroadcaster.createSocket(),
                 proxyServer.getBoundAddress().getPort(),
-                LegacyComponentSerializer.legacy().serialize(proxyServer.getConfiguration().getMotdComponent()),
+                LegacyComponentSerializer.legacySection().serialize(proxyServer.getConfiguration().getMotd()),
                 proxyServer.getBoundAddress().getAddress().getHostAddress(),
                 java.util.logging.Logger.getLogger("LANBroadcaster"));
         proxyServer.getScheduler().buildTask(this, this.broadcaster).schedule();


### PR DESCRIPTION
- Update to Velocity 3.0.1
The current code does not work in Velocity 3+ because the net.kyori.text library that was deprecated since Velocity 1.1.0 was removed in this version.
- Update gradle version
- Remove Sponge unused import